### PR TITLE
Update DQMGUI Dockerfile to version HG1510f

### DIFF
--- a/dqmgui/Dockerfile
+++ b/dqmgui/Dockerfile
@@ -1,17 +1,30 @@
 from cmssw/slc6-vanilla
+MAINTAINER Marco Rovere marco.rovere@cern.ch
+
+ENV INSTALL_DIR=/data/srv
+ENV HTTPG_VERSION=HG1510f
+ENV ARCH=slc6_amd64_gcc481
+EXPOSE 8060
 
 RUN yum install -y git \
- HEP_OSlibs_SL6 \
- e2fsprogs
+                   HEP_OSlibs_SL6 \
+                   e2fsprogs \
+                   hostname
 
+# We need to run under a user different from root, since our software will not install using the root account
 RUN useradd dqmgui && install -o dqmgui -d /data
-
 USER dqmgui
-WORKDIR /data
-EXPOSE 8080
-EXPOSE 8060
-RUN git clone https://github.com/dmwm/deployment.git cfg && cd cfg && git reset --hard HG1408a && cd ..
 
-RUN cfg/Deploy -R comp@HG1408a -r comp=comp.pre.rovere -t 7.4.5 -s 'prep sw post' /data dqmgui@7.4.5/bare
+RUN mkdir -p ${INSTALL_DIR}/ && cd ${INSTALL_DIR}
+WORKDIR ${INSTALL_DIR}
+RUN git clone git://github.com/dmwm/deployment.git cfg && cd cfg && git reset --hard ${HTTPG_VERSION}
+RUN cfg/Deploy -r "comp=comp.pre" -A ${ARCH} -R comp@${HTTPG_VERSION} -t ${HTTPG_VERSION} -s "prep sw post" $PWD dqmgui/bare
 
-CMD source /data/current/sw.pre.rovere/slc6_amd64_gcc481/cms/dqmgui/7.4.5/128/etc/profile.d/init.sh && /data/current/config/dqmgui/manage restart "I did read documentation" && while true; do sleep 100; done
+# Now set up sphinx to allow developing and building
+
+RUN . $PWD/current/*/*/external/apt/*/etc/profile.d/init.sh && \
+    apt-get install -y external+py2-sphinx+1.1.3
+
+USER root
+
+CMD source ${INSTALL_DIR}/current/sw.pre/${ARCH}/cms/dqmgui/*/128/etc/profile.d/init.sh && ${INSTALL_DIR}/current/config/dqmgui/manage restart 'I did read documentation' && while true; do sleep 100; done

--- a/dqmgui/Dockerfile_gcc493
+++ b/dqmgui/Dockerfile_gcc493
@@ -1,0 +1,31 @@
+from cmssw/slc6-vanilla
+MAINTAINER Marco Rovere marco.rovere@cern.ch
+
+ENV INSTALL_DIR=/data/srv
+ENV HTTPG_VERSION=HG1510f
+ENV ARCH=slc6_amd64_gcc493
+ENV COMP=comp
+EXPOSE 8060
+
+RUN yum install -y git \
+                   HEP_OSlibs_SL6 \
+                   e2fsprogs \
+                   hostname
+
+# We need to run under a user different from root, since our software will not install using the root account
+RUN useradd dqmgui && install -o dqmgui -d /data
+USER dqmgui
+
+RUN mkdir -p ${INSTALL_DIR}/ && cd ${INSTALL_DIR}
+WORKDIR ${INSTALL_DIR}
+RUN git clone git://github.com/dmwm/deployment.git cfg && cd cfg && git reset --hard ${HTTPG_VERSION}
+RUN cfg/Deploy -r "comp=${COMP}" -A ${ARCH} -R comp@${HTTPG_VERSION} -t ${HTTPG_VERSION} -s "prep sw post" $PWD dqmgui/bare
+
+# Now set up sphinx to allow developing and building
+
+RUN . $PWD/current/*/*/external/apt/*/etc/profile.d/init.sh && \
+    apt-get install -y external+py2-sphinx+1.1.3
+
+USER root
+
+CMD source ${INSTALL_DIR}/current/sw.pre/${ARCH}/cms/dqmgui/*/128/etc/profile.d/init.sh && ${INSTALL_DIR}/current/config/dqmgui/manage restart 'I did read documentation' && while true; do sleep 100; done


### PR DESCRIPTION
The DQMGUI Dockerfile has been reviewed and updated to bring the most
up-to-date version of the software.

Anchillary packages have been added on top of the cms-dqmgui package in order
to be able to locally build the server, since they are at present required only
at build-time and not listed as runtime dependencies.

With the current docker image the user is able to immediately run the server
out of the box and also to develop it: for this last step we recommend to run
the docker container mounting the proper DQMGUI source repository from an
external volume.

The application must be installed with a user different from root, for security
reasons built inside cms software stack.  The application is run under the root
account to ease the process of file creation/deletion on an externally mounted
volumes.