### PR TITLE
Add auth-proxy-server

### DIFF
--- a/docker-config.yaml
+++ b/docker-config.yaml
@@ -3,6 +3,8 @@ repositories:
     dmwm: admin
   alertscollector:
     dmwm: admin
+  auth-proxy-server:
+    dmwm: admin
   cc7:
     cmssw: admin
   cc8:


### PR DESCRIPTION
Auth-proxy-server is new reverse proxy server for cmsweb based on new CERN SSO OAuth OICD schema.