### PR TITLE
New entry for udp-server repository

### DIFF
--- a/docker-config.yaml
+++ b/docker-config.yaml
@@ -103,6 +103,8 @@ repositories:
     dmwm: write
   runregistry-backend:
     dmwm: write
+  udp-server:
+    dmwm: admin
 teams:
   cmssw:
   - tulamor


### PR DESCRIPTION
The new repository udp-server will contain images for UDP collector service used by Monitoring and CMSSW to collect UDP messages about access patterns in CMSSW jobs.