### PR TITLE
Added new sqoop repository for CMS sqoop jobs

### DIFF
--- a/docker-config.yaml
+++ b/docker-config.yaml
@@ -93,6 +93,8 @@ repositories:
     cmssw: write
   slc7-installer:
     cmssw: write
+  sqoop:
+    dmwm: admin
   t0_reqmon:
     dmwm: admin
   t0wmadatasvc:


### PR DESCRIPTION
The CMS Monitoring group needs to run series of sqoop jobs to dump CMS databases, e.g. DBS, Phedex, Rucio, etc. to HDFS. The new `sqoop` docker repository will contain proper image for software stack required for these actions.