### PR TITLE
Add the new DQM GUI frontend to cmssw repository

### DIFF
--- a/docker-config.yaml
+++ b/docker-config.yaml
@@ -111,6 +111,8 @@ repositories:
     dmwm: write
   runregistry-backend:
     dmwm: write
+  dqmgui-frontend:
+    dmwm: write
   udp-server:
     dmwm: admin
 teams:


### PR DESCRIPTION
At DQM we are building a new html/js frontend for the DQM GUI, we plan in deploying it under cmsweb so we can use the backend without having CORS problems.