### PR TITLE
Add token-manager image area

### DIFF
--- a/docker-config.yaml
+++ b/docker-config.yaml
@@ -139,6 +139,8 @@ repositories:
     dmwm: admin
   t0wmadatasvc:
     dmwm: admin
+  token-manager:
+    dmwm: admin
   tfaas:
     dmwm: admin
   workqueue:


### PR DESCRIPTION
We need a new image to manage CERN SSO OAuth2 tokens. This is placeholder for this image.