### PR TITLE
Add todorivanov to docker-config

### DIFF
--- a/docker-config.yaml
+++ b/docker-config.yaml
@@ -184,6 +184,7 @@ teams:
   - dmwmbot
   - goughes
   - amaltaro
+  - todorivanov
   owners:
   - cmsblddoc
   - smuzaffar


### PR DESCRIPTION
In order to be able to follow the instruction in the end to end deployment procedures for the WMCore services I need to be able to upload images to the cmssw area in dockerhub. Thanks in advance!