### PR TITLE
New area for k8snodemon service

### DIFF
--- a/docker-config.yaml
+++ b/docker-config.yaml
@@ -79,6 +79,8 @@ repositories:
     dmwm: admin
   http-exporter:
     dmwm: admin
+  k8snodemon:
+    dmwm: admin
   karma:
     dmwm: admin
   kerberos:


### PR DESCRIPTION
k8snodemon is a new service to monitor openstack k8s nodes and manage them accordingly.