### PR TITLE
include man in el8

### DIFF
--- a/el8/Dockerfile
+++ b/el8/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf install -y @DEFAULT_PACKAGES@ automake bash bzip2 bzip2-libs bzip2-devel
       libSM libX11 libX11-devel libxcrypt libXcursor libXext \
       libXft libXi libXinerama \
       libXmu libXpm libXpm-devel libXrandr libXrender \
-      java-1.8.0-openjdk-devel libtool m4 make \
+      java-1.8.0-openjdk-devel libtool m4 make man-db \
       ncurses ncurses-libs ncurses-devel nspr nss nss-util \
       openssl openssl-devel openssl-libs \
       perl perl-interpreter perl-libs \


### PR DESCRIPTION
Currently, in `cmssw-el8`, a command like `git cms-rebase-topic --help` produces the following error:
```
warning: failed to exec 'man': No such file or directory
fatal: no man viewer handled the request
```

`man` is provided by the rpm `man-db`. Since `cmssw-el8` is commonly being used for interactive development now, it should be included.