### PR TITLE
[EL8 CLEANUP] Add missing packages for runTheMatrix

### DIFF
--- a/el8/Dockerfile.runtime
+++ b/el8/Dockerfile.runtime
@@ -7,9 +7,9 @@ ADD CERN.repo               /tmp/CERN.repo
 ADD RPM-GPG-KEY-kojiv2      /tmp/RPM-GPG-KEY-kojiv2
 ADD fix_ssh_config.sh       /tmp/fix_ssh_config.sh
 
-RUN dnf install -y @DEFAULT_PACKAGES@ bash tcsh glibc libxcrypt openssl-libs libcom_err krb5-libs ncurses-libs perl \
+RUN dnf install -y @DEFAULT_PACKAGES@ bash tcsh glibc glibc-headers libxcrypt openssl-libs libcom_err krb5-libs ncurses-libs perl \
           perl-libs libX11 readline tcl tk mesa-libGLU libglvnd-glx libglvnd-opengl libXext libXft libXpm &&\
-    dnf install -y python2 python3 which &&\
+    dnf install -y python2 python3 which procps-ng &&\
     dnf install -y epel-release &&\
     dnf install -y @EPEL_PACKAGES@ apptainer &&\
     xcmd="@EXTRA_COMMAND@" &&\


### PR DESCRIPTION
`procps-ng` is needed to run the `ps` commands at the start of the container.
`glibc-headers` is needed for runTheMatrix.