### PR TITLE
Add pkg voms-clients-cpp to el8 runtime image

### DIFF
--- a/el8/Dockerfile.runtime
+++ b/el8/Dockerfile.runtime
@@ -11,7 +11,7 @@ RUN dnf install -y @DEFAULT_PACKAGES@ bash tcsh zsh glibc glibc-headers libxcryp
           perl-libs libX11 readline tcl tk mesa-libGLU libglvnd-glx libglvnd-opengl libXext libXft libXpm libaio libnsl &&\
     dnf install -y python2 python3 which procps-ng &&\
     dnf install -y epel-release &&\
-    dnf install -y @EPEL_PACKAGES@ apptainer &&\
+    dnf install -y @EPEL_PACKAGES@ voms-clients-cpp apptainer &&\
     xcmd="@EXTRA_COMMAND@" &&\
     if [ "$xcmd" = "" ] ; then xcmd=true; fi &&\
     eval $xcmd &&\


### PR DESCRIPTION
Solves unit test failures in https://github.com/cms-sw/cmsdist/pull/8626#issuecomment-1665773061 reporting:
```
Traceback (most recent call last):
  File "/pool/condor/dir_33737/jenkins/workspace/ib-run-pr-tests/CMSSW_13_3_X_2023-08-03-2300/bin/el8_amd64_gcc11/validateAlignments.py", line 374, in <module>
    main()
  File "/pool/condor/dir_33737/jenkins/workspace/ib-run-pr-tests/CMSSW_13_3_X_2023-08-03-2300/bin/el8_amd64_gcc11/validateAlignments.py", line 187, in main
    if not check_proxy():
  File "/pool/condor/dir_33737/jenkins/workspace/ib-run-pr-tests/CMSSW_13_3_X_2023-08-03-2300/bin/el8_amd64_gcc11/validateAlignments.py", line 44, in check_proxy
    subprocess.check_call(["voms-proxy-info", "--exists"],
  File "/pool/condor/dir_33737/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc11/external/python3/3.9.14-70b6957a795b7a66f76d8f6fe4fa6559/lib/python3.9/subprocess.py", line 368, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/pool/condor/dir_33737/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc11/external/python3/3.9.14-70b6957a795b7a66f76d8f6fe4fa6559/lib/python3.9/subprocess.py", line 349, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/pool/condor/dir_33737/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc11/external/python3/3.9.14-70b6957a795b7a66f76d8f6fe4fa6559/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/pool/condor/dir_33737/jenkins/workspace/ib-run-pr-tests/testBuildDir/el8_amd64_gcc11/external/python3/3.9.14-70b6957a795b7a66f76d8f6fe4fa6559/lib/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'voms-proxy-info'
```