### PR TITLE
Add pkg boost-python3 in grid image

### DIFF
--- a/el8/Dockerfile.grid
+++ b/el8/Dockerfile.grid
@@ -2,6 +2,7 @@ FROM @BASE_IMAGE_NAME@
 LABEL maintainer="CMS Build"
 LABEL name="CMS Worker Node on EL - Grid packages"
 
+RUN dnf --enablerepo=powertools install -y boost-python3
 RUN dnf install -y gfal2-util-scripts gfal2-all python3-gfal2-util &&\ 
     epel_pkgs="@EPEL_PACKAGES@" &&\
     if [ -n "$epel_pkgs" ] ; then dnf install -y $epel_pkgs; fi &&\


### PR DESCRIPTION
Ii is needed to install gfal pkgs