### PR TITLE
Add missing archs for grid images for el8

### DIFF
--- a/el8/config.yaml
+++ b/el8/config.yaml
@@ -50,6 +50,12 @@ groups:
       x86_64:
         tags:
           ${group1}-${group0}:
+      aarch64:
+        tags:
+          ${group1}-${group0}:
+      ppc64le:
+        tags:
+          ${group1}-${group0}:
   buildtime:
     docker: Dockerfile.${group0}
     from: ${container}:${group1}-grid


### PR DESCRIPTION
I forgot to add for aarch64 and ppc64le (needed since buildtime now is based on grid)