### PR TITLE
el9: building GCC requires libgcc

### DIFF
--- a/el9/Dockerfile.runtime
+++ b/el9/Dockerfile.runtime
@@ -6,7 +6,7 @@ ADD CERN.repo               /tmp/CERN.repo
 ADD RPM-GPG-KEY-kojiv2      /tmp/RPM-GPG-KEY-kojiv2
 ADD fix_ssh_config.sh       /tmp/fix_ssh_config.sh
 
-RUN dnf install -y @DEFAULT_PACKAGES@ bash tcsh zsh tar glibc glibc-headers libxcrypt openssl-libs libcom_err krb5-libs ncurses-libs \
+RUN dnf install -y @DEFAULT_PACKAGES@ bash tcsh zsh tar glibc glibc-devel libgcc libxcrypt openssl-libs libcom_err krb5-libs ncurses-libs \
           perl perl-libs libX11 readline tcl tk mesa-libGLU libglvnd-glx libglvnd-opengl libXext libXft libXpm libaio libnsl &&\
     dnf install -y python3 which procps-ng &&\
     dnf install -y epel-release &&\


### PR DESCRIPTION
12:09:34 error: Failed dependencies:
12:09:34 	libgcc_s.so.1()(64bit) is needed by external+gcc+12.3.1-40d504be6370b5a30e3947a6e575ca28-1-1.x86_64 12:09:34 	libgcc_s.so.1(GCC_3.0)(64bit) is needed by external+gcc+12.3.1-40d504be6370b5a30e3947a6e575ca28-1-1.x86_64 12:09:34 	libgcc_s.so.1(GCC_3.3)(64bit) is needed by external+gcc+12.3.1-40d504be6370b5a30e3947a6e575ca28-1-1.x86_64 12:09:34 	libgcc_s.so.1(GCC_3.4)(64bit) is needed by external+gcc+12.3.1-40d504be6370b5a30e3947a6e575ca28-1-1.x86_64 12:09:34 	libgcc_s.so.1(GCC_4.2.0)(64bit) is needed by external+gcc+12.3.1-40d504be6370b5a30e3947a6e575ca28-1-1.x86_64 12:09:34 	libgcc_s.so.1(GCC_4.3.0)(64bit) is needed by external+gcc+12.3.1-40d504be6370b5a30e3947a6e575ca28-1-1.x86_64 12:09:34 Reading Package Lists...