### PR TITLE
[alma8] Turn relative path into full path

### DIFF
--- a/alma8/Dockerfile
+++ b/alma8/Dockerfile
@@ -2,7 +2,7 @@ FROM @BASE_IMAGE_NAME@
 
 ADD bin/rpm-pkg-info.sh /tmp/rpm-pkg-info.sh
 
-RUN dnf install -y bash && ./tmp/rpm-pkg-info.sh BASE &&\
+RUN dnf install -y bash && /tmp/rpm-pkg-info.sh BASE &&\
       dnf install -y @DEFAULT_PACKAGES@ automake bzip2 bzip2-libs bzip2-devel \
       file file-libs fontconfig freetype gcc-c++  git glibc krb5-libs libaio \
       libcom_err libgomp libICE libidn \
@@ -43,4 +43,4 @@ RUN mkdir -p /cvmfs /afs /eos /etc/vomses /etc/grid-security /build /data /pool 
     touch /etc/tnsnames.ora &&\
     /tmp/fix_ssh_config.sh /etc/ssh/ssh_config && rm -f /tmp/fix_ssh_config.sh &&\
     sed -i -e s'|^ *allow  *setuid.*|allow setuid = no|;s|^ *enable  *overlay.*|enable overlay = no|;s|^ *enable  *underlay.*|enable underlay = yes|' /etc/apptainer/apptainer.conf &&\
-    ./tmp/rpm-pkg-info.sh IMAGE
+    /tmp/rpm-pkg-info.sh IMAGE


### PR DESCRIPTION
Fixing relative path as requested in https://github.com/cms-sw/cms-docker/pull/260#discussion_r1455268929
I believe this PR can wait until there is a new base `alma8` image.