### PR TITLE
Use NOTIFY_TO to tag GH users for image updates

### DIFF
--- a/bin/get_image_config.py
+++ b/bin/get_image_config.py
@@ -115,6 +115,7 @@ def process_tags(setup, data, images):
     images[-1]['TEST_NODE']=get_key('node', img_data)
     images[-1]['ARCHITECTURE']=arch
     images[-1]['BUILD_CONTEXT']="."
+    images[-1]['NOTIFY_TO']="all"
     for xkey in ['delete_pattern', 'expires_days', 'build_context']:
       val = get_key(xkey, img_data)
       if val:
@@ -125,7 +126,7 @@ def process_tags(setup, data, images):
     if ".variables" in data[0]:
       for v in data[0][".variables"]:
         images[-1][v] = get_key(v, img_data)
-        if (not v in ['SKIP_TESTS', 'CVMFS_UNPACKED', 'BUILD_DATE', 'MAIL_TO', 'CMS_COMPATIBLE_OS', 'CI_TESTS', 'BUILD_CONTEXT']) and images[-1][v]:
+        if (not v in ['SKIP_TESTS', 'CVMFS_UNPACKED', 'BUILD_DATE', 'NOTIFY_TO', 'CMS_COMPATIBLE_OS', 'CI_TESTS', 'BUILD_CONTEXT']) and images[-1][v]:
           chkdata.append("%s=%s" % (v, images[-1][v]))
 
     config_dir = get_key('config_dir', img_data)

--- a/bin/notify.yaml
+++ b/bin/notify.yaml
@@ -1,0 +1,2 @@
+teams:
+  all: iarspider, smuzaffar, aandvalenzuela

--- a/cms/config.yaml
+++ b/cms/config.yaml
@@ -21,7 +21,6 @@ groups:
       ${group}-cms:
         variables:
           OSG_WN_BASE: opensciencegrid/osg-wn:3.5-el8
-          MAIL_TO: muzaffar
           CMS_COMPATIBLE_OS: el8
         alias: ${group}-m-${daily}
         docker: Dockerfile.alma8
@@ -31,7 +30,6 @@ groups:
     alias: ${group}-wn-${daily}
     variables:
       SKIP_TESTS: true
-      MAIL_TO: muzaffar
     tags:
       ${group}-wn:
         from: library/almalinux:8

--- a/cs9/config.yaml
+++ b/cs9/config.yaml
@@ -13,7 +13,7 @@ groups:
     alias: ${group1}-${daily}
     from: quay.io/centos/centos:stream9
     variables:
-      MAIL_TO: externals-l2
+      NOTIFY_TO: externals-l2
     groups:
       x86_64:
         variables:

--- a/el8/config.yaml
+++ b/el8/config.yaml
@@ -61,7 +61,6 @@ groups:
     alias: ${group1}-${daily}
     from: ${container}:${group1}-grid
     variables:
-      MAIL_TO: externals-l2
     groups:
       x86_64:
         variables:


### PR DESCRIPTION
Default value for `NOTIFY_TO` is `all` (which contains the GH user names of the users that should be notified for any new image).

I am using `NOTIFY_TO: externals-l2` in `cs9` to try tagging cmssw teams too.