### PR TITLE
Update cms:rhel8(-x86_64) to cmssw/el8:x86_64-d20240109

### DIFF
--- a/cms/tags.yaml
+++ b/cms/tags.yaml
@@ -27,7 +27,7 @@ rhel8-itb-ppc64le: cmssw/el8:ppc64le-d20240110
 ########################
 rhel6: rhel6-m20211005
 rhel7: rhel7-m20220331
-rhel8: cmssw/el8:x86_64-d20231016
+rhel8: cmssw/el8:x86_64-d20240109
 rhel9: cmssw/el9:x86_64-d20240125
 
 #x86_64


### PR DESCRIPTION
`cmssw/el8:x86_64-d20240109` has been tested via `cmssw/cms:rhel8-itb`