### PR TITLE
[el9] Make sure to install openldap-compat which is needed by gfal2

### DIFF
--- a/el9/Dockerfile.grid
+++ b/el9/Dockerfile.grid
@@ -3,7 +3,7 @@ LABEL maintainer="CMS Build"
 LABEL name="CMS Worker Node on EL - Grid packages"
 
 RUN /tmp/rpm-pkg-info.sh BASE &&\
-    dnf install -y gfal2-util-scripts gfal2-all python3-gfal2-util xrootd-client &&\
+    dnf install -y gfal2-util-scripts gfal2-all python3-gfal2-util xrootd-client openldap-compat &&\
     dnf install -y @EPEL_PACKAGES@ myproxy &&\
     xcmd="@EXTRA_COMMAND@" &&\
     if [ "$xcmd" = "" ] ; then xcmd=true; fi &&\


### PR DESCRIPTION
Looks like gfal2 needs `openldap-compat` but is missing it dependency. So this PR makes sure that we have install it explicitly for grid containers