### PR TITLE
Fix dockerhub sync and docker tag cleanup jobs

### DIFF
--- a/bin/docker_sync.py
+++ b/bin/docker_sync.py
@@ -137,7 +137,6 @@ for team_name in hub_teams:
       print('No members found in yaml config file for "%s"' % team_name)
       members_in_yaml = []
     update_dockerhub(members_in_yaml, hub_team_members[1], team_name=team_name, what_to_sync='members')
-logout()
 if args.dryrun and changes_applied:
   print('\nDOCKER HUB CONFIGURATION CHANGED\n')
   sys.exit(1)

--- a/bin/docker_sync.py
+++ b/bin/docker_sync.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-from docker_utils import (get_repos, get_teams, get_permissions, get_members, logout, create_repo, create_team, 
+from docker_utils import (get_repos, get_teams, get_permissions, get_members, create_repo, create_team,
                           add_permissions, add_member, delete_repo, delete_team, delete_permissions, delete_member)
 from argparse import ArgumentParser
 import yaml

--- a/bin/docker_tag_delete.py
+++ b/bin/docker_tag_delete.py
@@ -5,7 +5,7 @@ from os.path import dirname, abspath
 from get_image_config import get_docker_images
 from datetime import datetime
 from argparse import ArgumentParser
-from docker_utils import get_token, delete_tag, logout, get_tags
+from docker_utils import get_token, delete_tag, get_tags
 import sys, re, yaml, os, glob
 
 def find_repos():

--- a/bin/docker_tag_delete.py
+++ b/bin/docker_tag_delete.py
@@ -59,4 +59,3 @@ for repo in find_repos():
         ntags.remove(tag)
     tags = ntags[:]
 
-logout()

--- a/bin/docker_tag_delete.py
+++ b/bin/docker_tag_delete.py
@@ -42,7 +42,7 @@ for repo in find_repos():
         tags = []
         print('Docker Hub user "%s" does not contain image "%s"'%(args.dockerUser, repo))
         break
-    print("Wroking on %s/%s" % (repo, image['IMAGE_TAG']))
+    print("Working on %s/%s" % (repo, image['IMAGE_TAG']))
     ntags = []
     for tag in tags:
       ntags.append(tag)

--- a/bin/docker_utils.py
+++ b/bin/docker_utils.py
@@ -23,7 +23,13 @@ def hub_request(uri, data=None, params=None, headers=None, method='GET', json=Fa
 
 def http_request(url, data=None, params=None, headers=None, method = 'GET', json=False):
   response = request(method=method, url=url, data=data,  params=params, headers=headers)
-  return response.json() if json else response
+  if json:
+    try:
+      response = response.json()
+    except ValueError as e:
+      print("No json response returned: ", e)
+      response = response.text
+  return response
 
 # get token for docker Registry API
 def get_registry_token(repo):
@@ -163,7 +169,12 @@ def delete_tag(repo, tag):
 
 def logout():
   uri = '/logout/'
-  return hub_request(uri, method='POST', json=True)['detail']
+  response = hub_request(uri, method='POST', json=True)
+  try:
+    response = loads(response)['detail']
+  except ValueError as e:
+    print("Logout request error: ", e)
+  return response
 
 def get_digest(image, arch, debug=False):
   tag = image.split(":")[-1]

--- a/bin/docker_utils.py
+++ b/bin/docker_utils.py
@@ -23,13 +23,7 @@ def hub_request(uri, data=None, params=None, headers=None, method='GET', json=Fa
 
 def http_request(url, data=None, params=None, headers=None, method = 'GET', json=False):
   response = request(method=method, url=url, data=data,  params=params, headers=headers)
-  if json:
-    try:
-      response = response.json()
-    except ValueError as e:
-      print("No json response returned: ", e)
-      response = response.text
-  return response
+  return response.json() if json else response
 
 # get token for docker Registry API
 def get_registry_token(repo):

--- a/bin/docker_utils.py
+++ b/bin/docker_utils.py
@@ -167,15 +167,6 @@ def delete_tag(repo, tag):
   response = hub_request(uri, method = 'DELETE')
   return (False, response, response.reason, response.text) if not response.ok else (response.ok,)
 
-def logout():
-  uri = '/logout/'
-  response = hub_request(uri, method='POST', json=True)
-  try:
-    response = loads(response)['detail']
-  except ValueError as e:
-    print("Logout request error: ", e)
-  return response
-
 def get_digest(image, arch, debug=False):
   tag = image.split(":")[-1]
   repo = image.split(":")[0]
@@ -262,7 +253,6 @@ def generate_yaml(username):
   docker_config = dict.fromkeys(['repositories', 'teams'])
   docker_config['teams'] = teams_dict
   docker_config['repositories'] = repositories_dict
-  logout()
   yaml_location = join(dirname(dirname(abspath(__file__))), 'generated-docker-config.yaml')
   with open(yaml_location, 'w') as file:
     yaml.safe_dump(docker_config, file, encoding='utf-8', allow_unicode=True, default_flow_style=False)


### PR DESCRIPTION
Dump `response.text` in case response is not a json object to workaround server error.

Fixes https://cmssdt.cern.ch/jenkins/job/dockerhub_synchronization/ and https://cmssdt.cern.ch/jenkins/job/cleanup-docker-tags/ jobs when dockerhub cannot logout and returns http 500 server error.