### PR TITLE
[el9] update-crypto-policies to allow SHA1

### DIFF
--- a/el9/Dockerfile.runtime
+++ b/el9/Dockerfile.runtime
@@ -20,6 +20,7 @@ RUN dnf install -y @DEFAULT_PACKAGES@ bash tcsh zsh tar glibc glibc-devel libgcc
     dnf install -y cern-gpg-keys CERN-CA-certs &&\
     update-ca-trust &&\
     dnf update -y ca-certificates &&\
+    update-crypto-policies --set DEFAULT:SHA1 &&\
     dnf clean all &&\
     mkdir -p /cvmfs /afs /eos /etc/vomses /etc/grid-security /build /data /pool /opt/cms /etc/ssh &&\
     mkdir -p /hdfs /mnt/hadoop /hadoop /cms /etc/cvmfs/SITECONF /lfs_roots /storage /scratch &&\


### PR DESCRIPTION
See https://twiki.cern.ch/twiki/bin/view/LCG/EL9vsSHA1CAs and https://mattermost.web.cern.ch/cms-o-and-c/channels/distributed-analysis/inmjbkc1f3ycmma35tgk5fn1oc