### PR TITLE
[el9] Install libstdc++-static which is needed by cuda-compatible-runtime

### DIFF
--- a/el9/Dockerfile
+++ b/el9/Dockerfile
@@ -16,7 +16,7 @@ RUN dnf install --disablerepo=epel -y man-db time bc nano strace xauth vim cmake
     dnf install -y screen &&\
     dnf clean all
 
-RUN dnf --enablerepo=crb install -y texinfo &&\
+RUN dnf --enablerepo=crb install -y texinfo libstdc++-static &&\
 	epel_pkgs="@EPEL_PACKAGES@" &&\
 	if [ -n "$epel_pkgs" ] ; then dnf install -y $epel_pkgs; fi &&\
 	xcmd="@EXTRA_COMMAND@" &&\


### PR DESCRIPTION
We build and deploy https://github.com/cms-patatrack/cuda-compatible-runtime on cvmfs. In order to build it we need  libstdc++-static