### PR TITLE
Add lndir

### DIFF
--- a/cc7/config.yaml
+++ b/cc7/config.yaml
@@ -33,7 +33,7 @@ groups:
     groups:
       x86_64:
         variables:
-          EXTRA_PACKAGES: doxygen compat-libstdc++-33 mesa-dri-drivers apptainer
+          EXTRA_PACKAGES: doxygen compat-libstdc++-33 mesa-dri-drivers apptainer imake
         tags:
           ${group1}:
       aarch64:

--- a/cc7/extra/cern.repo
+++ b/cc7/extra/cern.repo
@@ -1,6 +1,6 @@
 [cern]
-name=CentOS-7 - CERN [20241216]
-baseurl=http://linuxsoft.cern.ch/internal/yumsnapshot/20241216/cern/centos/7/cern/x86_64
+name=CentOS-7 - CERN [20250107]
+baseurl=http://linuxsoft.cern.ch/internal/yumsnapshot/20250107/cern/centos/7/cern/x86_64
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-cern

--- a/el8/Dockerfile
+++ b/el8/Dockerfile
@@ -20,7 +20,7 @@ RUN dnf install --disablerepo=epel -y man-db time bc nano strace perf xauth vim 
     dnf install -y screen &&\
     dnf clean all
 
-RUN dnf --enablerepo=powertools install -y texinfo libstdc++-static &&\
+RUN dnf --enablerepo=powertools install -y texinfo libstdc++-static imake &&\
 	epel_pkgs="@EPEL_PACKAGES@" &&\
 	if [ -n "$epel_pkgs" ] ; then dnf install -y $epel_pkgs; fi &&\
 	xcmd="@EXTRA_COMMAND@" &&\

--- a/el9/config.yaml
+++ b/el9/config.yaml
@@ -12,7 +12,7 @@ variables:
   CI_TESTS: stageout
   DEFAULT_PACKAGES:
   BUILD_DATE: $${now.strftime("%Y%m%d-%H%M%S")}
-  EPEL_PACKAGES:
+  EPEL_PACKAGES: imake
   EXTRA_COMMAND:
 groups:
   bootstrap:


### PR DESCRIPTION
`lndir` comes from the `imake` package in RHEL. This package is provided by different repos for each OS version:
* sl7: ~sl repo~ now in epel repo
* el8: powertools repo
* el9: epel repo

I tested the builds from the modified dockerfiles. They run successfully and `lndir` is available in the resulting containers.