### PR TITLE
Update cmssw/rhel6 to use new slc6 based containers

### DIFF
--- a/cms/tags.yaml
+++ b/cms/tags.yaml
@@ -4,7 +4,7 @@
 ########################
 #ITB images
 ########################
-rhel6-itb-x86_64: cmssw/slc6:x86_64-grid
+rhel6-itb-x86_64: cmssw/slc6:x86_64-grid-d20250621
 rhel7-itb-x86_64: cmssw/cc7:x86_64-d20250108
 rhel8-itb-x86_64: cmssw/el8:x86_64-d20250521
 rhel9-itb-x86_64: cmssw/el9:x86_64-d20250606
@@ -27,7 +27,7 @@ rhel9-itb: rhel9-itb-x86_64
 ########################
 #Production images
 ########################
-rhel6-x86_64: rhel6-m20211005
+rhel6-x86_64: cmssw/slc6:x86_64-grid-d20250621
 rhel7-x86_64: cmssw/cc7:x86_64-d20250108
 rhel8-x86_64: cmssw/el8:x86_64-d20250312
 rhel9-x86_64: cmssw/el9:x86_64-d20250311


### PR DESCRIPTION
This container has been tested in ITB already. This change will allow us to not depend on old style opensciencegrid/osg-wn container.

This should be merged on Monday , 21st July @ 9h00