### PR TITLE
Add cern alma10 repository to get CERN Grid root certificates

### DIFF
--- a/el10/Dockerfile.runtime
+++ b/el10/Dockerfile.runtime
@@ -2,6 +2,8 @@ FROM @BASE_IMAGE_NAME@
 LABEL maintainer="CMS Build"
 LABEL name="CMS Worker Node on EL - Runtime"
 
+ADD share/el10-CERN.repo        /tmp/CERN.repo
+ADD share/RPM-GPG-KEY-kojiv2    /tmp/RPM-GPG-KEY-kojiv2
 ADD share/fix_ssh_config.sh     /root/fix_ssh_config.sh
 
 RUN dnf install -y @DEFAULT_PACKAGES@ bash tcsh zsh tar glibc glibc-devel libgcc libxcrypt openssl-libs libcom_err krb5-libs ncurses-libs \
@@ -13,12 +15,19 @@ RUN dnf install -y @DEFAULT_PACKAGES@ bash tcsh zsh tar glibc glibc-devel libgcc
     if [ "$xcmd" = "" ] ; then xcmd=true; fi &&\
     eval $xcmd &&\
     echo el10 > /etc/cmsos &&\
+    cp /tmp/CERN.repo /etc/yum.repos.d/CERN.repo &&\
+    rpm --import /tmp/RPM-GPG-KEY-kojiv2 &&\
+    dnf install -y cern-gpg-keys CERN-CA-certs &&\
+    update-ca-trust &&\
+    dnf update -y ca-certificates &&\
+    update-crypto-policies --set DEFAULT:SHA1 &&\
     dnf clean all &&\
     mkdir -p /cvmfs /afs /eos /etc/vomses /etc/grid-security /build /data /pool /opt/cms /etc/ssh &&\
     mkdir -p /hdfs /mnt/hadoop /hadoop /cms /etc/cvmfs/SITECONF /lfs_roots /storage /scratch &&\
     touch /etc/tnsnames.ora &&\
     chmod +x /root/fix_ssh_config.sh &&\
     /root/fix_ssh_config.sh /etc/ssh/ssh_config &&\
+    rm -f /tmp/CERN.repo /tmp/RPM-GPG-KEY-kojiv2 &&\
     echo "Timestamp: @BUILD_DATE@"   > /image-build-info.txt &&\
     sed -i -e s'|^ *allow  *setuid.*|allow setuid = no|;s|^ *enable  *overlay.*|enable overlay = no|;s|^ *enable  *underlay.*|enable underlay = yes|' /etc/apptainer/apptainer.conf
 

--- a/share/el10-CERN.repo
+++ b/share/el10-CERN.repo
@@ -1,0 +1,8 @@
+[CERN]
+name=AlmaLinux-10 - CERN [HEAD]
+baseurl=http://linuxsoft.cern.ch/cern/alma/10/CERN/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-kojiv2
+exclude=puppet-agent
+priority=4


### PR DESCRIPTION
@smuzaffar this should, in theory, fix [TestDQMGUIUpload](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el10_amd64_gcc14/CMSSW_16_0_ROOT636_X_2025-09-11-2300/unitTestLogs/DQMServices/Demo#/12445-12445) test failing for el10. One can verify that the fix worked by running `openssl s_client -showcerts -servername cmsweb.cern.ch -connect cmsweb.cern.ch:443 </dev/null` - it should print "Verification: OK" among other things.