### PR TITLE
Update maintainer email address in index.html

### DIFF
--- a/docker-lxr/index.html
+++ b/docker-lxr/index.html
@@ -143,7 +143,7 @@
             <p><span class="red">Warning</span>: don't use use a web-crawler to try and download all of these pages: 
             the CGIs will feed you several <i>gigabytes</i> worth of generated HTML!</p>
             
-            <p>Send complaints, suggestions and praises to <a href="mailto:cmstalk+swdevtools@dovecotmta.cern.ch?cc=gartung@cern.ch&amp;subject=Comment%20about%20CMSSW%20LXR">the maintainer</a>.</p>
+            <p>Send complaints, suggestions and praises to <a href="mailto:cmstalk+swdevtools@dovecotmta.cern.ch&amp;subject=Comment%20about%20CMSSW%20LXR">the CMS SWDevTools CMSTalk channel</a> or <a href="https://mattermost.web.cern.ch/cms-o-and-c/channels/core-software"> the CMS Offline and Computing Core Software Mattermost channel</a>.</p>
           </div></td>
         </tr>
       </tbody>


### PR DESCRIPTION
@smuzaffar do you know the email address to use for the O&C Core Software Channel on CERN Mattermost? 
I would rather use that than my email for the cc field.