### PR TITLE
cs9: explicitly install redhat-rpm-config glibc-gconv-extra rpm-build

### DIFF
--- a/cs9/Dockerfile
+++ b/cs9/Dockerfile
@@ -1,6 +1,7 @@
 FROM @BASE_IMAGE_NAME@
 
-RUN dnf install -y automake bzip2 bzip2-libs bzip2-devel coreutils-single e2fsprogs \
+RUN dnf -y install redhat-rpm-config glibc-gconv-extra rpm-build &&\
+    dnf install -y automake bzip2 bzip2-libs bzip2-devel coreutils-single e2fsprogs \
     e2fsprogs-libs perl file file-libs fontconfig freetype gcc-c++ git glibc krb5-libs \
     libaio libcom_err libcom_err-devel libgomp libICE \
     libSM libX11 libX11-devel libxcrypt libXcursor libXext \
@@ -10,7 +11,7 @@ RUN dnf install -y automake bzip2 bzip2-libs bzip2-devel coreutils-single e2fspr
     java-1.8.0-openjdk-devel java-11-openjdk-devel java-17-openjdk-devel libtool m4 make \
     ncurses ncurses-libs ncurses-devel nspr nss nss-devel nss-util \
     openssl openssl-devel openssl-libs sssd-client \
-    patch popt popt-devel python3 readline readline-devel rpm-build \
+    patch popt popt-devel python3 readline readline-devel \
     rsync tcl tcsh time tk wget which zlib zsh tcl-devel tk-devel krb5-devel \
     bc strace tar zip unzip hostname nano libnsl procps-ng environment-modules && \
     dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&\


### PR DESCRIPTION
Otherwise `dnf install` fails with

```
Error: 
 Problem: package rpm-build-4.16.1.3-39.el9.x86_64 from appstream requires system-rpm-config, but none of the providers can be installed
  - package glibc-2.34-234.el9.x86_64 from @System requires (glibc-gconv-extra(x86-64) = 2.34-234.el9 if redhat-rpm-config), but none of the providers can be installed
  - cannot install the best candidate for the job
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```